### PR TITLE
fix: enable no kwargs for dict of rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,29 +26,30 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=500]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.12.1
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         args: [--config-file=pyproject.toml]
         files: src
         additional_dependencies: [pydantic~=2.0]
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
-    hooks:
-      - id: gitleaks
+  # Temporary disabled
+  # - repo: https://github.com/gitleaks/gitleaks
+  #   rev: v8.27.2
+  #   hooks:
+  #     - id: gitleaks
   - repo: https://github.com/pypa/pip-audit
     rev: v2.9.0
     hooks:
       - id: pip-audit
-        args: [--skip-editable]
+        args: [.]
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.0.0
+    rev: v4.2.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.1] - April, 2025
+## 0.10.2 - July, 2025
+
+### Fixes
+
+* `kwargs` as an optional parameter (since v0.10.0) wasn't totally implemented: *dictionary of rules* was missing (#47).
+
+## 0.10.1 - April, 2025
 
 ### Fixes
 
 * Unintentional breaking change on the action function parameter `input_data` (now deprecated).
 
-## [0.10.0] - April, 2025
+## 0.10.0 - April, 2025
 
 ### Features
 
@@ -25,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Enable Dependabot.
 
-## [0.9.0] - December, 2024
+## 0.9.0 - December, 2024
 
 ### Features
 
@@ -49,7 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Because of using `StringConstraints` (w/ Pydantic V2) rather than `constr()`, we can't use plain `YES` or `NO` (YAML booleans) as rule ids anymore. Use `"YES"` or `"NO"` instead in your YAML file.
 
-## [0.8.1] - September, 2024
+## 0.8.1 - September, 2024
 
 ### Fixes
 
@@ -59,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Fixes of code in the [A Simple Example](https://maif.github.io/arta/a_simple_example/) page.
 
-## [0.8.0] - July, 2024
+## 0.8.0 - July, 2024
 
 ### Features
 
@@ -75,7 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Function `sanitize_regex()` is converted to an instance method `get_sanitized_id()` of `BaseCondition` class.
 
-## [0.7.1] - June, 2024
+## 0.7.1 - June, 2024
 
 ### Features
 
@@ -92,7 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * You can now use *whitespaces* in a string within a *simple condition* (e.g., `input.text=="super hero"`) (#23).
 
 
-## [0.7.0b*] - April, 2024
+## 0.7.0b* - April, 2024
 
 *Beta release*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arta"
-version = "0.10.1"
+version = "0.10.2"
 requires-python = ">3.8.0"
 description = "A Python Rules Engine - Make rule handling simple"
 readme = "README.md"

--- a/src/arta/_engine.py
+++ b/src/arta/_engine.py
@@ -421,10 +421,6 @@ class RulesEngine:
                 # Get action function
                 action = rule_dict["action"]
 
-                # Trigger if not **kwargs
-                if "kwargs" not in inspect.signature(action).parameters:
-                    raise KeyError(f"The action function {action} must have a '**kwargs' parameter.")
-
                 # Create Rule instance
                 rule = Rule(
                     set_id=self.CONST_DFLT_RULE_SET_ID,

--- a/tests/unit/test_engine_errors.py
+++ b/tests/unit/test_engine_errors.py
@@ -93,20 +93,6 @@ import pydantic
                     "rule_str": {
                         "condition": lambda x: isinstance(x, str),
                         "condition_parameters": {"x": "input.to_check"},
-                        "action": lambda value: {"value": value},
-                        "action_parameters": {"value": "Missing **kwargs in action function."},
-                    },
-                }
-            },
-            None,
-            KeyError,
-        ),
-        (
-            {
-                "type": {
-                    "rule_str": {
-                        "condition": lambda x: isinstance(x, str),
-                        "condition_parameters": {"x": "input.to_check"},
                         "action_parameters": {"value": "Missing an action."},
                     },
                 }

--- a/tests/unit/test_engine_with_dict.py
+++ b/tests/unit/test_engine_with_dict.py
@@ -102,7 +102,7 @@ def test_dict_apply_rules(input_data, verbose, good_results):
             "super_power": {
                 "condition": lambda p: p in ["immortality", "time_travelling", "invisibility"],
                 "condition_parameters": {"p": "input.power"},
-                "action": lambda x, **kwargs: x,
+                "action": lambda x: x,
                 "action_parameters": {"x": "super"},
             },
             "minor_power": {


### PR DESCRIPTION
### What?
Since 0.10.0, `kwargs` parameter of action functions is optional. It was not the case for action functions used in a dictionary of rules.

### Have you done?
- [x] Code tests
- [] ~Update documentation~
- [x] Update [changelog](https://github.com/MAIF/arta/blob/main/CHANGELOG.md)

### Linked issues: (optional)
- Close #47
