### PR TITLE
documentation: clarify advanced guide link

### DIFF
--- a/docs/pages/how_to.md
+++ b/docs/pages/how_to.md
@@ -514,4 +514,4 @@ Well done! By executing this code you have:
     You will improve your rules' maintainability a lot.
     In some cases like proof-of-concepts or Jupyter notebook works, you will probably be happy with straightforward dictionaries.
 
-**Arta** has plenty more features to discover. If you want to learn more, go to the next chapter: [Advanced User Guide](parameters.md).
+**Arta** has plenty more features to discover. If you want to learn more, go to the advanced guide's [parameters](parameters.md) page.


### PR DESCRIPTION
Summary
- Clarifies the final link on the How to page so it accurately points readers to the advanced guide's parameters page.
- Keeps the existing `parameters.md` target, which is present in the docs navigation and builds to `/parameters/`.
- Limits the change to `docs/pages/how_to.md`.

Validation
- `D:\AI_practice\chores\tmp\arta-docs-venv\Scripts\python.exe -m mkdocs build -f docs\mkdocs.yaml --strict --site-dir D:\AI_practice\chores\tmp\arta-docs-site` - passed; documentation built successfully and the generated How to page links to `../parameters/`.
- `python -m tox -e py311` - passed; 95 tests passed with 12 existing deprecation warnings.
- `git diff --check` - passed; Git reported only the local LF-to-CRLF working-tree warning.

Notes
- Closes #63.
- Documentation-only change; no runtime compatibility impact.
- No changelog update included because this only clarifies an existing docs link.
